### PR TITLE
Check command

### DIFF
--- a/pip/commands/check.py
+++ b/pip/commands/check.py
@@ -41,11 +41,11 @@ class CheckCommand(Command):
         `installed_dists`.
 
         """
-        installed_names = set(d.project_name for d in installed_dists)
+        installed_names = set(d.project_name.lower() for d in installed_dists)
 
         missing_requirements = set()
         for requirement in dist.requires():
-            if requirement.project_name not in installed_names:
+            if requirement.project_name.lower() not in installed_names:
                 missing_requirements.add(requirement)
                 yield requirement
 

--- a/pip/commands/check.py
+++ b/pip/commands/check.py
@@ -16,7 +16,7 @@ class CheckCommand(Command):
     def run(self, options, args):
         all_requirements_met = True
 
-        installed = get_installed_distributions()
+        installed = get_installed_distributions(skip=())
         for dist in installed:
 
             missing_requirements = self.get_missing_requirements(dist, installed)


### PR DESCRIPTION
Some fixes for your `check` command.
- Normalize names to lowercase
- Tell `get_installed_distributions` not to skip any packages like `setuptools`, etc.
##### Before

```
$ pip check
pdbpp 0.7.2 requires pygments, which is not installed.
bpython 0.13.1 requires pygments, which is not installed.
devpi-web 2.2.2 requires pygments, which is not installed.
distribute 0.7.3 requires setuptools, which is not installed.
Jinja2 2.7.3 requires markupsafe, which is not installed.
pyramid 1.5.2 requires setuptools, which is not installed.
pyramid 1.5.2 requires zope.deprecation, which is not installed.
waitress 0.8.9 requires setuptools, which is not installed.
zope.interface 4.1.1 requires setuptools, which is not installed.
```
##### After

```
$ pip check
pyramid 1.5.2 requires zope.deprecation, which is not installed.
```

The latter is correct in my situation because my virtualenv had `Pygments` and `setuptools` installed but not `zope.deprecation`.
